### PR TITLE
Allow background changes to apply immediately

### DIFF
--- a/seoul256-theme.el
+++ b/seoul256-theme.el
@@ -344,6 +344,11 @@
         (setq seoul256-current-bg dark-bg)
       (setq seoul256-current-bg light-bg))
 
+    (if (member theme custom-enabled-themes)
+        (let ((custom--inhibit-theme-enable nil))
+          (cherry-seoul256-apply theme style dark-fg light-fg dark-bg light-bg))
+      (cherry-seoul256-apply theme style dark-fg light-fg dark-bg light-bg)
+      
     (seoul256-apply theme style dark-fg light-fg dark-bg light-bg)))
 
 (defun seoul256-switch-background ()


### PR DESCRIPTION
Currently, changing `seoul256-background` or running your background-change helper functions only works for subsequent frames, not the existing frame.

Adding this snippet allows any such changes to immediately apply to the current frame:

```
(if (member theme custom-enabled-themes)
    (let ((custom--inhibit-theme-enable nil))
      (cherry-seoul256-apply theme style dark-fg light-fg dark-bg light-bg))
  (cherry-seoul256-apply theme style dark-fg light-fg dark-bg light-bg))
```

Let me know if you have any questions or if I'm mistaken in this.

Thanks for your hard work on this port.